### PR TITLE
IDEM-164

### DIFF
--- a/app/src/context/Exchange.tsx
+++ b/app/src/context/Exchange.tsx
@@ -110,10 +110,25 @@ export const ExchangeProvider: React.FC<{
             "Content-Type": "application/json"
           }
         });
+
         shareDetailsAlert(randomTempPassword);
       } catch (error: any) {
-        console.log(error.response.data);
-        Alert.alert(error.response.data);
+        if (axios.isAxiosError(error)) {
+          if (error.response) {
+            console.log("axios error response :", error.response.data);
+          } else if (error.request) {
+            console.log("axios error request :", error.request);
+          } else {
+            console.log("axios other error :", error.message);
+          }
+        } else {
+          console.log("unknown error :", error);
+        }
+
+        Alert.alert(
+          "Unable to register with the provided credential",
+          "The email might already be in use"
+        );
       }
     }
   };


### PR DESCRIPTION
FIX #164 

Context:
- App crash when sign up to Coinstash for the second time

Cause:
- Coinstash return error as a graphQL error which isn't expected by current error handler

Change:
- Check the catch error type and log error accordingly
- hard coded Alert error message dialog for now for simple fix (proper handler would look into graphQL error object)

<img src="https://user-images.githubusercontent.com/10498040/176352202-4926fb5c-a955-4197-b21f-ba4362bbd178.png" width="300">