### PR TITLE
IDEM-228

### DIFF
--- a/app/src/navigation/LinkingConfiguration.ts
+++ b/app/src/navigation/LinkingConfiguration.ts
@@ -15,8 +15,9 @@ const linking: LinkingOptions<MainTabParamList> = {
         }
       },
       SupportedExchanges: {
+        initialRouteName: "Vendors",
         screens: {
-          Back: "exchange/back",
+          Vendors: "exchange/vendors",
           VendorDetails: "exchange/vendors/:id"
         }
       },

--- a/app/src/navigation/MainTabNavigator.tsx
+++ b/app/src/navigation/MainTabNavigator.tsx
@@ -1,45 +1,92 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { FontAwesome5 } from "@expo/vector-icons";
 import DocumentsStackNavigator from "./DocumentsStackNavigator";
 import ProfileStackNavigator from "./ProfileStackNavigator";
 import VendorsStackNavigator from "./VendorsStackNavigator";
-import { ParamListBase, RouteProp } from "@react-navigation/native";
+import {
+  CommonActions,
+  ParamListBase,
+  RouteProp,
+  useNavigation
+} from "@react-navigation/native";
 import colors from "../styles/colors";
+import { MainTabNavigation, VendorStackNavigation } from "../types/navigation";
+import { Linking } from "react-native";
 
 export type MainTabParamList = {
   Profile: undefined;
-  SupportedExchanges: undefined;
+  SupportedExchanges: undefined | { screen: string; params: any };
   DocumentsTab: undefined;
 };
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 
-const TabNavigator = () => (
-  <Tab.Navigator
-    initialRouteName="Profile"
-    screenOptions={({ route }) => ({
-      headerShown: false,
-      tabBarIcon: (tabProps) => renderTabIcon(route, tabProps),
-      tabBarActiveTintColor: colors.blue,
-      tabBarInactiveTintColor: colors.gray
-    })}
-  >
-    <Tab.Screen name="Profile" component={ProfileStackNavigator} />
-    <Tab.Screen
-      name="SupportedExchanges"
-      component={VendorsStackNavigator}
-      options={{ title: "Supported Exchanges" }}
-    />
-    <Tab.Screen
-      name="DocumentsTab"
-      options={{
-        title: "Documents"
-      }}
-      component={DocumentsStackNavigator}
-    />
-  </Tab.Navigator>
-);
+type Navigation = MainTabNavigation<"Profile">;
+
+const TabNavigator = () => {
+  const navigation = useNavigation<Navigation>();
+
+  useEffect(() => {
+    Linking.addEventListener("url", ({ url }) => {
+      if (url.includes("exchange/vendors")) {
+        const [vendorId] = url.slice(-1);
+        navigation.dispatch(
+          CommonActions.reset({
+            type: "tab",
+            index: 0,
+            routes: [
+              {
+                name: "SupportedExchanges",
+                state: {
+                  type: "stack",
+                  index: 1,
+                  routes: [
+                    {
+                      name: "Vendors"
+                    },
+                    {
+                      name: "VendorDetails",
+                      params: {
+                        id: vendorId
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          })
+        );
+      }
+    });
+  }, []);
+
+  return (
+    <Tab.Navigator
+      initialRouteName="Profile"
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarIcon: (tabProps) => renderTabIcon(route, tabProps),
+        tabBarActiveTintColor: colors.blue,
+        tabBarInactiveTintColor: colors.gray
+      })}
+    >
+      <Tab.Screen name="Profile" component={ProfileStackNavigator} />
+      <Tab.Screen
+        name="SupportedExchanges"
+        component={VendorsStackNavigator}
+        options={{ title: "Supported Exchanges" }}
+      />
+      <Tab.Screen
+        name="DocumentsTab"
+        options={{
+          title: "Documents"
+        }}
+        component={DocumentsStackNavigator}
+      />
+    </Tab.Navigator>
+  );
+};
 
 export default TabNavigator;
 

--- a/app/src/navigation/MainTabNavigator.tsx
+++ b/app/src/navigation/MainTabNavigator.tsx
@@ -16,7 +16,7 @@ import { Linking } from "react-native";
 
 export type MainTabParamList = {
   Profile: undefined;
-  SupportedExchanges: undefined;
+  SupportedExchanges: undefined | { screen: string; params: any };
   DocumentsTab: undefined;
 };
 

--- a/app/src/navigation/MainTabNavigator.tsx
+++ b/app/src/navigation/MainTabNavigator.tsx
@@ -11,12 +11,12 @@ import {
   useNavigation
 } from "@react-navigation/native";
 import colors from "../styles/colors";
-import { MainTabNavigation, VendorStackNavigation } from "../types/navigation";
+import { MainTabNavigation } from "../types/navigation";
 import { Linking } from "react-native";
 
 export type MainTabParamList = {
   Profile: undefined;
-  SupportedExchanges: undefined | { screen: string; params: any };
+  SupportedExchanges: undefined;
   DocumentsTab: undefined;
 };
 

--- a/app/src/navigation/MainTabNavigator.tsx
+++ b/app/src/navigation/MainTabNavigator.tsx
@@ -3,10 +3,13 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { FontAwesome5 } from "@expo/vector-icons";
 import DocumentsStackNavigator from "./DocumentsStackNavigator";
 import ProfileStackNavigator from "./ProfileStackNavigator";
-import VendorsStackNavigator from "./VendorsStackNavigator";
+import VendorsStackNavigator, {
+  VendorStackParamList
+} from "./VendorsStackNavigator";
 import {
   CommonActions,
   ParamListBase,
+  PathConfig,
   RouteProp,
   useNavigation
 } from "@react-navigation/native";
@@ -16,7 +19,9 @@ import { Linking } from "react-native";
 
 export type MainTabParamList = {
   Profile: undefined;
-  SupportedExchanges: undefined | { screen: string; params: any };
+  SupportedExchanges:
+    | undefined
+    | { screen: string; params: PathConfig<VendorStackParamList> };
   DocumentsTab: undefined;
 };
 

--- a/app/src/navigation/VendorsStackNavigator.tsx
+++ b/app/src/navigation/VendorsStackNavigator.tsx
@@ -4,7 +4,7 @@ import VendorsScreen from "./screens/VendorsScreen";
 import VendorDetailsScreen from "./screens/VendorDetails";
 
 export type VendorStackParamList = {
-  Back: undefined;
+  Vendors: undefined;
   VendorDetails: { id: number };
 };
 
@@ -14,7 +14,7 @@ const VendorsStackNavigator = () => {
   return (
     <Stack.Navigator>
       <Stack.Screen
-        name="Back"
+        name="Vendors"
         component={VendorsScreen}
         options={() => ({
           headerShown: false
@@ -25,7 +25,8 @@ const VendorsStackNavigator = () => {
         component={VendorDetailsScreen}
         options={() => {
           return {
-            title: ""
+            title: "",
+            headerBackTitle: "Back"
           };
         }}
       />

--- a/app/src/navigation/screens/VendorsScreen.tsx
+++ b/app/src/navigation/screens/VendorsScreen.tsx
@@ -7,7 +7,7 @@ import useVendorsList from "../../hooks/useVendorsList";
 import { AntDesign } from "@expo/vector-icons";
 import colors from "../../styles/colors";
 
-type Navigation = VendorStackNavigation<"Back">;
+type Navigation = VendorStackNavigation<"Vendors">;
 
 const VendorsScreen: React.FC = () => {
   const navigation = useNavigation<Navigation>();


### PR DESCRIPTION
#228 

fix navigation stack broken when opening VendorDetails though deeplink

# Note : 
navigation works differently base on app state
1. App is not running 
2. App is freshly start running without any navigation 
3. App is running and already been navigation pages

LinkingConfiguration handle case 1 and 3
Linking.addEventListener("url") in MainTabNavigation handle case 2