### PR TITLE
Replace Alert.Prompt With Dialog

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -46,6 +46,7 @@
     "moment": "^2.29.3",
     "react": "17.0.2",
     "react-native": "0.68.2",
+    "react-native-dialog": "^9.2.2",
     "react-native-fast-openpgp": "^2.4.1",
     "react-native-gesture-handler": "~2.2.1",
     "react-native-get-random-values": "~1.8.0",

--- a/app/src/navigation/screens/ClaimScreen.tsx
+++ b/app/src/navigation/screens/ClaimScreen.tsx
@@ -417,7 +417,11 @@ const OtpDialog: React.FC<{
   return (
     <Dialog.Container visible={showDialog} onBackdropPress={onCancel}>
       <Dialog.Title>Enter your verification code</Dialog.Title>
-      <Dialog.Input onChangeText={setOtpCode} autoFocus={true}></Dialog.Input>
+      <Dialog.Input
+        onChangeText={setOtpCode}
+        autoFocus={true}
+        keyboardType={"number-pad"}
+      ></Dialog.Input>
       <Dialog.Button
         onPress={onCancel}
         label="Cancel"

--- a/app/src/navigation/screens/ClaimScreen.tsx
+++ b/app/src/navigation/screens/ClaimScreen.tsx
@@ -415,13 +415,11 @@ const OtpDialog: React.FC<{
   const [otpCode, setOtpCode] = React.useState<string>();
 
   return (
-    <Dialog.Container visible={showDialog}>
+    <Dialog.Container visible={showDialog} onBackdropPress={onCancel}>
       <Dialog.Title>Enter your verification code</Dialog.Title>
-      <Dialog.Input onChangeText={setOtpCode}></Dialog.Input>
+      <Dialog.Input onChangeText={setOtpCode} autoFocus={true}></Dialog.Input>
       <Dialog.Button
-        onPress={() => {
-          onCancel();
-        }}
+        onPress={onCancel}
         label="Cancel"
         bold={true}
         color="#007ff9"

--- a/app/src/navigation/screens/ClaimScreen.tsx
+++ b/app/src/navigation/screens/ClaimScreen.tsx
@@ -10,15 +10,17 @@ import {
   ScrollView,
   Dimensions
 } from "react-native";
+import Dialog from "react-native-dialog";
 import { Input, Switch } from "@rneui/themed";
 import DateTimePicker from "@react-native-community/datetimepicker";
+
 import commonStyles from "../../styles/styles";
 import {
   ProfileStackNavigation,
   ProfileStackNavigationRoute
 } from "../../types/navigation";
 import { getClaimFromType } from "../../utils/claim-utils";
-import { Claim } from "../../types/claim";
+import { Claim, RequestOptResponse } from "../../types/claim";
 import { FileList, Button } from "../../components";
 import { useClaimsStore } from "../../context/ClaimsStore";
 import { useDocumentStore } from "../../context/DocumentStore";
@@ -48,8 +50,9 @@ const ClaimScreen: React.FC = () => {
   const [showDatePickerForFieldId, setShowDatePickerForFieldId] =
     React.useState<string>();
   const [isVerifying, setIsVerifying] = React.useState<boolean>(false);
-
   const [rawDate, setRawDate] = React.useState<Date>();
+  const [showOtpDialog, setShowOtpDialog] = React.useState<boolean>(false);
+  const [otpContext, setOtpContext] = React.useState<RequestOptResponse>();
 
   const {
     saveAndCheckBirthday,
@@ -99,7 +102,6 @@ const ClaimScreen: React.FC = () => {
     ((isVerifying && selectedFileIds.length > 0) || !isVerifying);
 
   React.useEffect(() => {
-    console.log({ userClaim });
     if (userClaim?.type === "EmailCredential" && userClaim.verified) {
       setDisableButton(true);
     }
@@ -115,40 +117,8 @@ const ClaimScreen: React.FC = () => {
     try {
       const otpResponse = await api.requestOtp({ mobileNumber });
       if (otpResponse.hash && otpResponse.expiryTimestamp) {
-        Alert.prompt("Enter your verification code", "", [
-          {
-            text: "OK",
-            onPress: async (value: string | undefined) => {
-              if (!value) return;
-
-              try {
-                const verifyOtp = await api.verifyOtp({
-                  hash: otpResponse.hash,
-                  code: value,
-                  expiryTimestamp: otpResponse.expiryTimestamp,
-                  mobileNumber: mobileNumber
-                });
-
-                if (verifyOtp) {
-                  addClaim(claim.type, formState, selectedFileIds, true);
-                  Alert.alert("Your mobile has been verified");
-                  navigation.reset({
-                    routes: [{ name: "Home" }]
-                  });
-                } else {
-                  Alert.alert("Please try again, verification code invalid");
-                }
-              } catch (error: any) {
-                Alert.alert(AlertTitle.Error, error?.message);
-              }
-            }
-          },
-          {
-            text: "Cancel",
-            onPress: () => console.log("Cancel Pressed"),
-            style: "cancel"
-          }
-        ]);
+        setOtpContext(otpResponse);
+        setShowOtpDialog(true);
       }
     } catch (error) {
       console.error(error);
@@ -157,8 +127,47 @@ const ClaimScreen: React.FC = () => {
     setLoading(false);
   };
 
+  const handleSubmitOtp = React.useCallback(
+    async (otpCode: string | undefined) => {
+      if (!otpCode || !otpContext) return;
+      const { hash, expiryTimestamp } = otpContext;
+      const mobileNumber = formState["mobileNumber"];
+
+      try {
+        const verifyOtp = await api.verifyOtp({
+          hash,
+          code: otpCode,
+          expiryTimestamp,
+          mobileNumber: mobileNumber
+        });
+
+        if (verifyOtp) {
+          addClaim(claim.type, formState, selectedFileIds, true);
+          Alert.alert("Your mobile has been verified");
+          navigation.reset({
+            routes: [{ name: "Home" }]
+          });
+        } else {
+          Alert.alert("Please try again, verification code invalid");
+        }
+      } catch (error: any) {
+        Alert.alert(AlertTitle.Error, error?.message);
+      }
+    },
+    [otpContext, api, addClaim, navigation]
+  );
+
   return (
     <View style={commonStyles.screen}>
+      <OtpDialog
+        showDialog={showOtpDialog}
+        onCancel={() => setShowOtpDialog(false)}
+        onSubmit={(otpCode) => {
+          handleSubmitOtp(otpCode).then(() => {
+            setShowOtpDialog(false);
+          });
+        }}
+      />
       <ScrollView style={commonStyles.screenContent}>
         <View>
           {claim.fields.map((field) => {
@@ -395,5 +404,35 @@ const VerificationFiles: React.FC<{
         </>
       ) : null}
     </View>
+  );
+};
+
+const OtpDialog: React.FC<{
+  showDialog: boolean;
+  onCancel: () => void;
+  onSubmit: (otpCode?: string) => void;
+}> = ({ showDialog, onCancel, onSubmit }) => {
+  const [otpCode, setOtpCode] = React.useState<string>();
+
+  return (
+    <Dialog.Container visible={showDialog}>
+      <Dialog.Title>Enter your verification code</Dialog.Title>
+      <Dialog.Input onChangeText={setOtpCode}></Dialog.Input>
+      <Dialog.Button
+        onPress={() => {
+          onCancel();
+        }}
+        label="Cancel"
+        bold={true}
+        color="#007ff9"
+      />
+      <Dialog.Button
+        onPress={() => {
+          onSubmit(otpCode);
+        }}
+        label="OK"
+        color="#007ff9"
+      />
+    </Dialog.Container>
   );
 };

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -7160,6 +7160,11 @@ react-native-codegen@^0.0.17:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
+react-native-dialog@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/react-native-dialog/-/react-native-dialog-9.2.2.tgz#f16921dd071d17daf1e5d98fb084e1837694f009"
+  integrity sha512-d2w3fyqB6G8Os0DYJKnfVl6PgqQwplW8dHSvzkQpczXzmX5V4BXOJTTXqoiKwI+nsS6QEHYb6Bk8VG7vV9WuXQ==
+
 react-native-fast-openpgp@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/react-native-fast-openpgp/-/react-native-fast-openpgp-2.4.1.tgz#a746c235102e0fc8d855d7789bf13cc9d83960c8"


### PR DESCRIPTION
## Context
Currently mobile claims screen use Alert.Prompt which is only available on iOS for OTP input
Making developing and testing on Android a hassle

This PR replace iOS Prompt with Cross platform Dialog that looks similar to prompt on iOS
## iOS

<img src="https://user-images.githubusercontent.com/10498040/184068512-561e7916-5f15-4422-af0c-dd23058f9f2f.png" width="240">

## Android
<img src="https://user-images.githubusercontent.com/10498040/184068580-93d43981-b800-4f0a-bb53-6e74f725d140.png" width="240">

