### PR TITLE
Fix Passport Document Field title

### DIFF
--- a/app/src/data/documents.ts
+++ b/app/src/data/documents.ts
@@ -86,15 +86,15 @@ const documents: Document[] = [
     title: "Passport",
     fields: [
       {
-        title: "Issue date",
+        title: "Issue Date",
         type: "date"
       },
       {
-        title: "Expiry date",
+        title: "Expiry Date",
         type: "date"
       },
       {
-        title: "Document number",
+        title: "Document Number",
         type: "string"
       }
     ]


### PR DESCRIPTION
Fix casing of Passport Document Fields' title

<img width="377" alt="Screenshot 2023-04-04 at 9 31 15 am" src="https://user-images.githubusercontent.com/10498040/229649336-7efe7897-9c30-4b0a-b633-7b31fd9f2b6d.png">
